### PR TITLE
Added and refactored/formatted some documentation.

### DIFF
--- a/copilot-libraries.cabal
+++ b/copilot-libraries.cabal
@@ -1,8 +1,7 @@
 cabal-version:       >=1.10
 name:                copilot-libraries
 version:             2.1.1
-synopsis:            A Haskell-embedded DSL for monitoring hard real-time
-                     distributed systems.
+synopsis:            Libraries for the Copilot language.
 description:
   Libraries for the Copilot language.
   .
@@ -19,6 +18,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Lee Pike, Robin Morisset, Alwyn Goodloe, Sebastian Niller,
                      Nis Nordby Wegmann
+homepage:            https://github.com/leepike/copilot-libraries
 maintainer:          leepike@gmail.com
 stability:           Experimental
 category:            Language, Embedded

--- a/src/Copilot/Library/Clocks.hs
+++ b/src/Copilot/Library/Clocks.hs
@@ -1,47 +1,61 @@
---------------------------------------------------------------------------------
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
---------------------------------------------------------------------------------
-
--- | A library that generates new clocks based on a base period.
--- Usage, supposing @v@ is a Copilot variable, then
+-- | 
+-- Module: Clocks
+-- Description: Clocks based on a base period and phase
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
+--
+-- This library generates new clocks based on a base period and phase.
+--
+-- = Example Usage
+-- 
+-- Also see @Examples/ClockExamples.hs@ in the
+-- <https://github.com/leepike/Copilot/tree/master/Examples Copilot repository>.
+--
 -- @
--- clk ( period 3 ) ( phase 1 )
+--     'clk' ( 'period' 3 ) ( 'phase' 1 )
 -- @
+--
 -- is equivalent to a stream of values like:
+--
 -- @
--- cycle [False, True, False]
+--     cycle [False, True, False]
 -- @
+--
 -- that generates a stream of values
+--
 -- @
--- False True False False True False False True False ...
--- 0     1    2     3     4    5     6     7    8
+--     False True False False True False False True False ...
+--     0     1    2     3     4    5     6     7    8
 -- @
+--
 -- That is true every 3 ticks (the period) starting on the 1st tick (the phase).
--- Constraints:
--- The period must be greater than 0.
--- The phase must be greater than or equal to 0.
--- The phase must be less than the period.
 
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Copilot.Library.Clocks
   ( clk, clk1, period, phase ) where
 
-import Prelude ( Integral, fromIntegral, ($))
+import Prelude ()
 import qualified Prelude as P
 import Copilot.Language
 
 data ( Integral a ) => Period a = Period a
 data ( Integral a ) => Phase  a = Phase  a
 
+-- | Constructor for a 'Period'. Note that period must be greater than 0.
 period :: ( Integral a ) => a -> Period a
 period = Period
 
+-- | Constructor for a 'Phase'. Note that phase must be greater than or equal
+-- to 0, and must be less than the period.
 phase :: ( Integral a ) => a -> Phase a
 phase  = Phase
 
--- clk generates a clock that counts n ticks by using an array of size n
-clk :: ( Integral a ) => Period a -> Phase a -> Stream Bool
+-- | Generate a clock that counts every @n@ ticks, starting at tick @m@, by
+-- using an array of size @n@.
+clk :: ( Integral a ) =>
+       Period a       -- ^ Period @n@ of clock
+       -> Phase a     -- ^ Phase @m@ of clock
+       -> Stream Bool -- ^ Clock signal - 'True' on clock ticks, 'False' otherwise
 clk ( Period period' ) ( Phase phase' ) = clk'
   where clk' = if period' P.< 1 then
                    badUsage ( "clk: clock period must be 1 or greater" )
@@ -56,10 +70,12 @@ clk ( Period period' ) ( Phase phase' ) = clk'
                                    ++ clk'
 
 
--- clk1 generates a clock that counts n ticks by using a
--- counter variable of integral type a
-clk1 :: ( Integral a, Typed a )
-        => Period a -> Phase a -> Stream Bool
+-- | This follows the same convention as 'clk', but uses a counter variable of
+-- integral type /a/ rather than an array.
+clk1 :: ( Integral a, Typed a ) =>
+        Period a       -- ^ Period @n@ of clock
+        -> Phase a     -- ^ Phase @m@ of clock
+        -> Stream Bool -- ^ Clock signal - 'True' on clock ticks, 'False' otherwise
 clk1 ( Period period' ) ( Phase phase' ) =
     if period' P.< 1 then
         badUsage ( "clk1: clock period must be 1 or greater" )

--- a/src/Copilot/Library/LTL.hs
+++ b/src/Copilot/Library/LTL.hs
@@ -1,24 +1,31 @@
---------------------------------------------------------------------------------
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
---------------------------------------------------------------------------------
-
--- | Bounded Linear Temporal Logic (LTL) operators.  For a bound @n@, a property
+-- | 
+-- Module: LTL
+-- Description: Bounded Linear Temporal Logic (LTL) operators
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
+--
+-- Bounded Linear Temporal Logic (LTL) operators. For a bound @n@, a property
 -- @p@ holds if it holds on the next @n@ transitions (between periods).  If
 -- @n == 0@, then the trace includes only the current period.  For example,
+--
 -- @
--- eventually 3 p
+--   eventually 3 p
 -- @
+--
 -- holds if @p@ holds at least once every four periods (3 transitions).
 --
--- Interface: see Examples/LTLExamples.hs You can embed an LTL specification
--- within a Copilot specification using the form:
+-- /Interface:/ See @Examples/LTLExamples.hs@ in the
+-- <https://github.com/leepike/Copilot/tree/master/Examples Copilot repository>.
+-- 
+-- You can embed an LTL specification within a Copilot specification using the
+-- form:
+--
 -- @
 --   operator spec
 -- @
 --
 -- For some properties, stream dependencies may not allow their specification.
 -- In particular, you cannot determine the "future" value of an external
--- variable.  In general, the ptLTL library is probaby more useful.
+-- variable.  In general, the "Copilot.Library.PTLTL" library is probably more useful.
 
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -30,19 +37,21 @@ import Copilot.Library.Utils
 
 
 -- | Property @s@ holds at the next period.  For example:
+--
 -- @
 --           0 1 2 3 4 5 6 7
 -- s      => F F F T F F T F ...
 -- next s => F F T F F T F ...
 -- @
--- Note: s must have sufficient history to drop a value from it.
+-- Note: s must have sufficient history to 'drop' a value from it.
 next :: Stream Bool -> Stream Bool
 next = drop ( 1 :: Int )
 
 
 -- | Property @s@ holds for the next @n@ periods.  We require @n >= 0@. If @n ==
--- 0@, then @s@ holds in the current period.  E.g., if @p = always 2 s@, then we
+-- 0@, then @s@ holds in the current period, e.g., if @p = always 2 s@, then we
 -- have the following relationship between the streams generated:
+--
 -- @
 --      0 1 2 3 4 5 6 7
 -- s => T T T F T T T T ...
@@ -56,11 +65,15 @@ always n = nfoldl1 ( fromIntegral n + 1 ) (&&)
 -- then @s@ holds in the current period.  We require @n >= 0@.  E.g., if @p =
 -- eventually 2 s@, then we have the following relationship between the streams
 -- generated:
+--
 -- @
 -- s => F F F T F F F T ...
 -- p => F T T T F T T T ...
 -- @
-eventually :: ( Integral a ) => a -> Stream Bool -> Stream Bool
+eventually :: ( Integral a ) =>
+              a -- ^ 'n'
+              -> Stream Bool -- ^ 's'
+              -> Stream Bool
 eventually n = nfoldl1 ( fromIntegral n + 1 ) (||)
 
 

--- a/src/Copilot/Library/Libraries.hs
+++ b/src/Copilot/Library/Libraries.hs
@@ -1,8 +1,7 @@
---------------------------------------------------------------------------------
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
---------------------------------------------------------------------------------
-
--- | Main import module for the front-end lanugage.
+-- | 
+-- Module: Libraries
+-- Description: Main import module for libraries
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
 
 module Copilot.Library.Libraries (
     module Copilot.Library.Clocks

--- a/src/Copilot/Library/PTLTL.hs
+++ b/src/Copilot/Library/PTLTL.hs
@@ -1,12 +1,16 @@
---------------------------------------------------------------------------------
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
---------------------------------------------------------------------------------
-
--- | Provides past-time linear-temporal logic (ptLTL operators).
+-- | 
+-- Module: PTLTL
+-- Description: Past-Time Linear-Temporal Logic
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
 --
--- Interface: see Examples/PTLTLExamples.hs.
+-- Provides past-time linear-temporal logic (ptLTL operators).
+--
+-- /Interface:/ See @Examples/PTLTLExamples.hs@ in the
+-- <https://github.com/leepike/Copilot/tree/master/Examples Copilot repository>.
+--
 -- You can embed a ptLTL specification within a Copilot specification using
 -- the form:
+--
 -- @
 --   operator stream
 -- @
@@ -16,7 +20,7 @@
 module Copilot.Library.PTLTL
     ( since, alwaysBeen, eventuallyPrev, previous ) where
 
-import Prelude ( ($) )
+import Prelude ()
 import Copilot.Language
 
 -- | Did @s@ hold in the previous period?

--- a/src/Copilot/Library/RegExp.hs
+++ b/src/Copilot/Library/RegExp.hs
@@ -1,4 +1,12 @@
--- | A regular expression librariy.
+-- | 
+-- Module: RegExp
+-- Description: Regular expression library
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
+--
+-- A regular expression library.
+--
+-- For examples, see @Examples/RegExpExamples.hs@ in the
+-- <https://github.com/leepike/Copilot/tree/master/Examples Copilot repository>.
 
 module Copilot.Library.RegExp ( copilotRegexp, copilotRegexpB ) where
 

--- a/src/Copilot/Library/Stacks.hs
+++ b/src/Copilot/Library/Stacks.hs
@@ -1,8 +1,38 @@
---------------------------------------------------------------------------------
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
---------------------------------------------------------------------------------
-
--- | Stack machine.
+-- | 
+-- Module: Stacks
+-- Description: Stream for a stack machine
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
+-- 
+-- This is a stream for a stack machine.
+--
+-- The stack is created from a specified depth, a specified start value, and
+-- three input streams:
+--
+-- * a pop signal which pops off the stack when true,
+-- * a push signal which pushes the value from the push stream onto the stack when true,
+-- * a push stream.
+-- The resultant stream is the top value of the stack.
+--
+-- In 'stack' the push signal takes priority over the pop signal in the event
+-- that both are true in the same tick. This priority is reversed in 'stack''.
+-- 
+-- Here is an example sequence with one stack of each type, both depth 3 and
+-- starting value 0:
+--
+-- @ 
+-- popSignal:   pushSignal:  pushValue:   stack:       stack':     
+-- false        true         100          0            0           
+-- false        true         101          100          100         
+-- true         true         102          101          101         
+-- true         false        103          100          102         
+-- true         false        104          0            101         
+-- true         false        105          0            100         
+-- true         false        106          0            0           
+-- @
+-- 
+-- Note the difference at the 4th tick after /popSignal/ and /pushSignal/ were
+-- both true.  Note also that one cannot pop the start value off the stack -
+-- that is, the stack is never empty.
 
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -11,25 +41,15 @@ module Copilot.Library.Stacks
 
 import Copilot.Language
 
-type PushSignal    = Stream Bool
-type PopSignal     = Stream Bool
-type PushStream  a = Stream a
-type StackTop    a = Stream a
-
-
--- stack and stack' streams
---
--- for the stack stream, the PopSignal has precedence
--- over the PushSignal in case both are true in the same tick
---
--- for the stack' stream, the PushSignal has precedence
--- over the PopSignal in case both are true in the same tick
-stack, stack' :: ( Integral a, Typed b )
-         => a -> b
-         -> PopSignal
-         -> PushSignal
-         -> PushStream b
-         -> StackTop   b
+-- | Stack stream in which the pop signal has precedence over the push signal
+-- in case both are true in the same tick
+stack :: (Integral a, Typed b) =>
+         a              -- ^ Depth
+         -> b           -- ^ Start value
+         -> Stream Bool -- ^ Pop signal
+         -> Stream Bool -- ^ Push signal
+         -> Stream b    -- ^ Push stream
+         -> Stream b    -- ^ Stack top
 stack depth startValue
   popSignal pushSignal pushValue =
   let depth'      = fromIntegral depth
@@ -51,7 +71,15 @@ stack depth startValue
 
    in toStack $ replicate depth' stackValue
 
-
+-- | Stack stream in which the push signal has precedence over the pop signal
+-- in case both are true in the same tick
+stack' :: (Integral a, Typed b) =>
+         a              -- ^ Depth
+         -> b           -- ^ Start value
+         -> Stream Bool -- ^ Pop signal
+         -> Stream Bool -- ^ Push signal
+         -> Stream b    -- ^ Push stream
+         -> Stream b    -- ^ Stack top
 stack' depth startValue
   popSignal pushSignal pushValue =
   let depth'      = fromIntegral depth

--- a/src/Copilot/Library/Statistics.hs
+++ b/src/Copilot/Library/Statistics.hs
@@ -1,8 +1,9 @@
---------------------------------------------------------------------------------
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
---------------------------------------------------------------------------------
-
--- | Basic bounded statistics.  In the following, a bound @n@ is given stating
+-- | 
+-- Module: Statistics
+-- Description: Basic bounded statistics
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
+--
+-- Basic bounded statistics.  In the following, a bound @n@ is given stating
 -- the number of periods over which to compute the statistic (@n == 1@ computes
 -- it only over the current period).
 

--- a/src/Copilot/Library/Utils.hs
+++ b/src/Copilot/Library/Utils.hs
@@ -1,19 +1,23 @@
---------------------------------------------------------------------------------
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
---------------------------------------------------------------------------------
-
--- | Utility bounded-list functions (e.g., folds, scans, etc.)
+-- | 
+-- Module: Utils
+-- Description: Utility bounded-list functions (e.g., folds, scans, etc.)
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
+--
+-- Utility bounded-list functions (e.g., folds, scans, etc.)
 
 module Copilot.Library.Utils
-    ( take, tails, nfoldl, nfoldl1, nfoldr, nfoldr1,
-      nscanl, nscanr, nscanl1, nscanr1,
-      case', (!!), cycle ) 
+       ( -- * Functions similar to the Prelude functions on lists
+         take, tails, cycle,
+         -- ** Folds
+         nfoldl, nfoldl1, nfoldr, nfoldr1,
+         -- ** Scans
+         nscanl, nscanr, nscanl1, nscanr1,
+         -- ** Indexing
+         case', (!!)) 
 where
 
 import Copilot.Language
 import qualified Prelude as P
-
--- | functions similar to the Prelude functions on lists
 
 tails :: ( Typed a )
          => Stream a -> [ Stream a ]
@@ -23,9 +27,6 @@ tails s = [ drop x s | x <- [ 0 .. ] ]
 take :: ( Integral a, Typed b )
         => a -> Stream b -> [ Stream b ]
 take n s = P.take ( fromIntegral n ) $ tails s
-
-
--- Folds
 
 nfoldl :: ( Typed a, Typed b )
           => Int -> ( Stream a -> Stream b -> Stream a )
@@ -46,9 +47,6 @@ nfoldr1 :: ( Typed a )
            => Int -> ( Stream a -> Stream a -> Stream a )
                   ->   Stream a -> Stream a
 nfoldr1 n f s = foldr1 f $ take n s
-
-
--- Scans
 
 nscanl :: ( Typed a, Typed b )
           => Int -> ( Stream a -> Stream b -> Stream a )
@@ -71,8 +69,8 @@ nscanr1 :: ( Typed a )
 nscanr1 n f s = scanr1 f $ take n s
 
 
--- Case-like function, the index of the first predicate that is true
--- in the predicate list selects the stream result, if no predicate
+-- | Case-like function: The index of the first predicate that is true
+-- in the predicate list selects the stream result. If no predicate
 -- is true, the last element is chosen (default element)
 case' :: ( Typed a )
          => [ Stream Bool ] -> [ Stream a ] -> Stream a
@@ -86,7 +84,8 @@ case' predicates alternatives =
   in case'' predicates alternatives
 
 
--- | Index.  WARNING: very expensive!  Consider using this only for very short lists.
+-- | Index.  WARNING: Very expensive!  Consider using this only for very short
+-- lists.
 (!!) :: ( Typed a, Integral a )
         => [ Stream a ] -> Stream a -> Stream a
 ls !! n = let indices      = map

--- a/src/Copilot/Library/Voting.hs
+++ b/src/Copilot/Library/Voting.hs
@@ -1,17 +1,36 @@
---------------------------------------------------------------------------------
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
---------------------------------------------------------------------------------
-
--- | An implementation of the Boyer-Moore Majority Vote Algorithm for Copilot.
+-- | 
+-- Module: Voting
+-- Description: Implementation of the Boyer-Moore Majority Vote Algorithm
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
 --
--- For details of the Boyer-Moore Majority Vote Algorithm see the following
--- papers:
+-- This is an implementation of the Boyer-Moore Majority Vote Algorithm for
+-- Copilot, which solves the majority vote problem in linear time and constant
+-- memory in two passes. 'majority' implements the first pass, and 'aMajority'
+-- the second pass. For details of the Boyer-Moore Majority Vote Algorithm see
+-- the following papers:
 --
--- * Wim H. Hesselink,
--- \"The Boyer-Moore Majority Vote Algorithm\", 2005
+-- * <http://www.cs.rug.nl/~wim/pub/whh348.pdf Wim H. Hesselink, \"The Boyer-Moore Majority Vote Algorithm\", 2005>
 --
--- * Robert S. Boyer and J Strother Moore,
--- \"MJRTY - A Fast Majority Vote Algorithm\", 1982
+-- * <ftp://net9.cs.utexas.edu/pub/techreports/tr81-32.pdf Robert S. Boyer and J Strother Moore, \"MJRTY - A Fast Majority Vote Algorithm\", 1981>
+--
+-- In addition, <https://github.com/leepike/copilot-discussion/blob/master/tutorial/copilot_tutorial.pdf An Introduction to Copilot> in
+-- <https://github.com/leepike/copilot-discussion copilot-discussion> explains
+-- a form of this code in section 4.
+--
+-- For instance, with four streams passed to 'majority', and the candidate stream
+-- then passed to 'aMajority':
+--
+-- @
+-- vote1:       vote2:       vote3:       vote4:       majority:    aMajority:
+-- 0            0            0            0            0            true
+-- 1            0            0            0            0            true
+-- 1            1            0            0            1            false
+-- 1            1            1            0            1            true
+-- 1            1            1            1            1            true
+-- @
+--
+-- For other examples, see @Examples/VotingExamples.hs@ in the
+-- <https://github.com/leepike/Copilot/tree/master/Examples Copilot repository>.
 
 {-# LANGUAGE RebindableSyntax #-}
 
@@ -21,9 +40,10 @@ module Copilot.Library.Voting
 import Copilot.Language
 import qualified Prelude as P
 
---------------------------------------------------------------------------------
-
-majority :: (P.Eq a, Typed a) => [Stream a] -> Stream a
+-- | Majority vote first pass: choosing a candidate.
+majority :: (P.Eq a, Typed a) =>
+            [Stream a] -- ^ Vote streams
+            -> Stream a -- ^ Candidate stream
 majority []     = badUsage "majority: empty list not allowed"
 majority (x:xs) = majority' xs x 1
 
@@ -40,9 +60,12 @@ majority' (x:xs) can cnt =
       where 
       inCnt cnt' = majority' xs can' cnt'
 
---------------------------------------------------------------------------------
-
-aMajority :: (P.Eq a, Typed a) => [Stream a] -> Stream a -> Stream Bool
+-- | Majority vote second pass: checking that a candidate indeed has more than
+-- half the votes.
+aMajority :: (P.Eq a, Typed a) =>
+             [Stream a] -- ^ Vote streams
+             -> Stream a -- ^ Candidate stream
+             -> Stream Bool -- ^ True if candidate holds majority
 aMajority [] _ = badUsage "aMajority: empty list not allowed"
 aMajority xs can =
   let


### PR DESCRIPTION
In the course of trying to learn Copilot, I found that documentation in copilot-libraries was in need of some help. Only a few spots actually needed it written (and RegExp.hs and Utils.hs still do, it seems), and in some others it just needed rearranging and formatting for Haddock to make better use of it.
