### PR TITLE
Fix FlexibleContexts build failure on GHC 7.10.1

### DIFF
--- a/src/Copilot/Library/RegExp.hs
+++ b/src/Copilot/Library/RegExp.hs
@@ -8,6 +8,8 @@
 -- For examples, see @Examples/RegExpExamples.hs@ in the
 -- <https://github.com/leepike/Copilot/tree/master/Examples Copilot repository>.
 
+{-# LANGUAGE FlexibleContexts #-}
+
 module Copilot.Library.RegExp ( copilotRegexp, copilotRegexpB ) where
 
 import Text.ParserCombinators.Parsec


### PR DESCRIPTION
Building with GHC 7.10.1 produces this error:

```
src/Copilot/Library/RegExp.hs:273:7:
    Non type-variable argument
      in the constraint: Control.Monad.State.Class.MonadState NumT m
    (Use FlexibleContexts to permit this)
    When checking that ‘enumSyms'’ has the inferred type
      enumSyms' :: forall (m :: * -> *) t.
                   Control.Monad.State.Class.MonadState NumT m =>
                   RegExp t -> m (RegExp t)
    In an equation for ‘enumSyms’:
        enumSyms rexp
          = evalState (enumSyms' rexp) 0
          where
              enumSyms' (RSymbol s)
                = do { num <- get;
                       .... }
              enumSyms' (ROr r1 r2)
                = do { r1' <- enumSyms' r1;
                       .... }
              enumSyms' (RConcat r1 r2)
                = do { r1' <- enumSyms' r1;
                       .... }
              enumSyms' (RStar r)
                = do { r' <- enumSyms' r;
                       .... }
              enumSyms' other = return other
Failed to install copilot-libraries-2.1.1
```
